### PR TITLE
Disable folders flooding

### DIFF
--- a/fstab.x86
+++ b/fstab.x86
@@ -1,13 +1,13 @@
 none			/cache		tmpfs	nosuid,nodev,noatime	defaults
 
 /devices/*/block/sr*		auto	auto	defaults		voldmanaged=cdrom:auto
-/devices/*/usb*/*		auto	auto	defaults		voldmanaged=usb:auto,encryptable=userdata
+/devices/*/usb*/*		auto	auto	defaults		voldmanaged=usb:auto
 /devices/*/mmc0:a*/*		auto	auto	defaults		voldmanaged=sdcard1:auto,encryptable=userdata
 /devices/*/*sdmmc*/*		auto	auto	defaults		voldmanaged=sdcard1:auto,encryptable=userdata
 /devices/*/80860F14:01/mmc_*	auto	auto	defaults		voldmanaged=sdcard1:auto,encryptable=userdata
 /devices/*/80860F14:02/mmc_*	auto	auto	defaults		voldmanaged=sdcard1:auto,encryptable=userdata
 /devices/*/80860F16:00/mmc_*	auto	auto	defaults		voldmanaged=sdcard1:auto,encryptable=userdata
 /devices/*/PNP0FFF:00/mmc_*	auto	auto	defaults		voldmanaged=sdcard1:auto,encryptable=userdata
-/devices/*/*/sd*		auto	auto	defaults,uid=1000,gid=1000		voldmanaged=usb
-/devices/*/*/nvme*		auto	auto	defaults,uid=1000,gid=1000		voldmanaged=usb
+/devices/*/*/sd*		auto	auto	defaults,uid=1000,gid=1000		voldmanaged=disk
+/devices/*/*/nvme*		auto	auto	defaults,uid=1000,gid=1000		voldmanaged=disk
 /dev/block/zram0        none    swap    defaults	        zramsize=52%,max_comp_streams=4,swapprio=10,notrim


### PR DESCRIPTION
Make BlissOS NOT to creat folders flooding into every mounted partitions into both inner SSD and USB drive, such as《Android》、《Alarms》、《Audiobooks》、《DCIM》、《Documents》、《Downloads》《Movies》、《Music》、《Notifications》、《Pictures》、《Podcast》、《Recordings》and《Ringtones》.

![A.png](https://user-images.githubusercontent.com/69227436/210762868-a38ac960-c5dd-4754-b322-c7e061248ccb.png)