### PR TITLE
add keylayout for Steam Input virtual x360 controller

### DIFF
--- a/keylayout/Vendor_28de_Product_11ff.kl
+++ b/keylayout/Vendor_28de_Product_11ff.kl
@@ -1,0 +1,36 @@
+# Copyright (C) 2014 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Steam Input virtual x360
+
+key 304 BUTTON_A
+key 305 BUTTON_B
+key 307 BUTTON_X
+key 308 BUTTON_Y
+key 310 BUTTON_L1
+key 311 BUTTON_R1
+key 315 BUTTON_START
+key 314 BACK
+key 316 HOME
+key 317 BUTTON_THUMBL
+key 318 BUTTON_THUMBR
+
+axis 0x00 X
+axis 0x01 Y
+axis 0x03 Z
+axis 0x04 RZ
+axis 0x05 GAS
+axis 0x02 BRAKE
+axis 0x10 HAT_X
+axis 0x11 HAT_Y


### PR DESCRIPTION
Steam Input on Linux uses uinput to create virtual Xbox 360 controllers. The said controllers can be passed into QEMU guests with `-device virtio-input-host-pci,evdev=/dev/input/event*`. Providing a keylayout file for them so that analog axes are mapped correctly. It is useful when running BlissOS QEMU with VirGL inside gamescope session, and would allow Steam Deck controllers to work correctly in the VM when configured correctly.
<img src="https://github.com/BlissRoms-x86/device_generic_common/assets/22017945/b6136e29-645b-4fa7-ac91-2d1ddefb284a" width="400px">

example qemu command:
[boot.sh.txt](https://github.com/BlissRoms-x86/device_generic_common/files/12664540/boot.sh.txt)

