### PR TITLE
Steam Deck: use deck sensor hal, set props for audio support, 90/270 rotation workaround, disable uinput power button

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -79,36 +79,35 @@ function init_hal_audio()
 
 	if [ "$BOARD" == "Jupiter" ]
 	then
-		fifo_path=/data/local/tmp/ucm_fifo
-		rm -f $fifo_path
-		mkfifo -m 600 $fifo_path
-		chown audioserver $fifo_path
-		nohup bash -c "while true; do echo 'open Valve-Jupiter-1 set _verb HiFi' > $fifo_path & while true; do cat $fifo_path; echo; done | alsaucm -n -i 1>/dev/null 2>/dev/null;done" &
+		alsaucm -c Valve-Jupiter-1 set _verb HiFi
 
 		pcm_card=$(cat /proc/asound/cards | grep acp5x | awk '{print $1}')
 		# headset microphone on d0, 32bit only
 		set_property hal.audio.in.headset "pcmC${pcm_card}D0c"
 		set_property hal.audio.in.headset.format 1
-		#set_property hal.audio.in.headset.command "alsaucm -c Valve-Jupiter-1 set _verb HiFi set _enadev Headset"
-		set_property hal.audio.in.headset.command "echo set _disdev Mic set _enadev Headset > $fifo_path"
+		amixer -c ${pcm_card} sset 'Headset Mic',0 on
 
 		# internal microphone on d0, 32bit only
 		set_property hal.audio.in.mic "pcmC${pcm_card}D0c"
 		set_property hal.audio.in.mic.format 1
-		#set_property hal.audio.in.mic.command "alsaucm -c Valve-Jupiter-1 set _verb HiFi set _enadev Mic"
-		set_property hal.audio.in.mic.command "echo set _disdev Headset set _enadev Mic > $fifo_path"
+		amixer -c ${pcm_card} sset 'Int Mic',0 on
+		amixer -c ${pcm_card} sset 'DMIC Enable',0 on
 
 		# headphone jack on d0, 32bit only
 		set_property hal.audio.out.headphone "pcmC${pcm_card}D0p"
 		set_property hal.audio.out.headphone.format 1
-		#set_property hal.audio.out.headphone.command "alsaucm -c Valve-Jupiter-1 set _verb HiFi set _enadev Headphones"
-		set_property hal.audio.out.headphone.command "echo set _disdev Speaker set _enadev Headphones > $fifo_path"
+		amixer -c ${pcm_card} sset 'Headphone',0 on
 
 		# speaker on d1, 16bit only
 		set_property hal.audio.out.speaker "pcmC${pcm_card}D1p"
 		set_property hal.audio.out.speaker.format 0
-		#set_property hal.audio.out.speaker.command "alsaucm -c Valve-Jupiter-1 set _verb HiFi set _enadev Speaker"
-		set_property hal.audio.out.speaker.command "echo set _disdev Headphones set _enadev Speaker > $fifo_path"
+		amixer -c ${pcm_card} sset 'Left DSP RX1 Source',0 ASPRX1
+		amixer -c ${pcm_card} sset 'Right DSP RX1 Source',0 ASPRX2
+		amixer -c ${pcm_card} sset 'Left DSP RX2 Source',0 ASPRX1
+		amixer -c ${pcm_card} sset 'Right DSP RX2 Source',0 ASPRX2
+		amixer -c ${pcm_card} sset 'Left DSP1 Preload',0 on
+		amixer -c ${pcm_card} sset 'Right DSP1 Preload',0 on
+
 
 		# enable hdmi audio on the 3rd output, but it really depends on how docks wire things
 		# to make matters worse, jack detection on alsa does not seem to always work on my setup, so a dedicated hdmi hal might want to send data to all ports instead of just probing

--- a/init.sh
+++ b/init.sh
@@ -374,6 +374,11 @@ function init_hal_media()
 		set_property ro.yuv420.disable false
 	fi
 
+	if [ "$BOARD" == "Jupiter" ]
+	then
+		FFMPEG_CODEC2_PREFER=${FFMPEG_CODEC2_PREFER:-1}
+	fi
+
 #FFMPEG Codec Setup
 ## Turn on/off FFMPEG OMX by default
 	if [ "$FFMPEG_OMX_CODEC" -ge "1" ]; then

--- a/init.sh
+++ b/init.sh
@@ -521,6 +521,13 @@ function init_hal_sensors()
             elif [ "$hal_sensors" != "kbd" ] | [ hal_sensors=iio ]; then
                 has_sensors=true
             fi
+
+            # is steam deck?
+            if [ "$BOARD" == "Jupiter" ]
+            then
+                hal_sensors=deck
+                has_sensors=true
+            fi
     fi
 
     set_property ro.iio.accel.quirks "no-trig,no-event"

--- a/init.sh
+++ b/init.sh
@@ -570,6 +570,7 @@ function init_hal_sensors()
             # is steam deck?
             if [ "$BOARD" == "Jupiter" ]
             then
+                set_property poweroff.disable_virtual_power_button 1
                 hal_sensors=jupiter
                 has_sensors=true
             fi

--- a/init.sh
+++ b/init.sh
@@ -76,6 +76,51 @@ function init_hal_audio()
 	esac
 
 	[ -z "$(getprop ro.hardware.audio.primary)" ] && setprop ro.hardware.audio.primary x86
+
+	if [ "$BOARD" == "Jupiter" ]
+	then
+		fifo_path=/data/local/tmp/ucm_fifo
+		rm -f $fifo_path
+		mkfifo -m 600 $fifo_path
+		chown audioserver $fifo_path
+		nohup bash -c "while true; do echo 'open Valve-Jupiter-1 set _verb HiFi' > $fifo_path & while true; do cat $fifo_path; echo; done | alsaucm -n -i 1>/dev/null 2>/dev/null;done" &
+
+		pcm_card=$(cat /proc/asound/cards | grep acp5x | awk '{print $1}')
+		# headset microphone on d0, 32bit only
+		set_property hal.audio.in.headset "pcmC${pcm_card}D0c"
+		set_property hal.audio.in.headset.format 1
+		#set_property hal.audio.in.headset.command "alsaucm -c Valve-Jupiter-1 set _verb HiFi set _enadev Headset"
+		set_property hal.audio.in.headset.command "echo set _disdev Mic set _enadev Headset > $fifo_path"
+
+		# internal microphone on d0, 32bit only
+		set_property hal.audio.in.mic "pcmC${pcm_card}D0c"
+		set_property hal.audio.in.mic.format 1
+		#set_property hal.audio.in.mic.command "alsaucm -c Valve-Jupiter-1 set _verb HiFi set _enadev Mic"
+		set_property hal.audio.in.mic.command "echo set _disdev Headset set _enadev Mic > $fifo_path"
+
+		# headphone jack on d0, 32bit only
+		set_property hal.audio.out.headphone "pcmC${pcm_card}D0p"
+		set_property hal.audio.out.headphone.format 1
+		#set_property hal.audio.out.headphone.command "alsaucm -c Valve-Jupiter-1 set _verb HiFi set _enadev Headphones"
+		set_property hal.audio.out.headphone.command "echo set _disdev Speaker set _enadev Headphones > $fifo_path"
+
+		# speaker on d1, 16bit only
+		set_property hal.audio.out.speaker "pcmC${pcm_card}D1p"
+		set_property hal.audio.out.speaker.format 0
+		#set_property hal.audio.out.speaker.command "alsaucm -c Valve-Jupiter-1 set _verb HiFi set _enadev Speaker"
+		set_property hal.audio.out.speaker.command "echo set _disdev Headphones set _enadev Speaker > $fifo_path"
+
+		# enable hdmi audio on the 3rd output, but it really depends on how docks wire things
+		# to make matters worse, jack detection on alsa does not seem to always work on my setup, so a dedicated hdmi hal might want to send data to all ports instead of just probing
+		pcm_card=$(cat /proc/asound/cards | grep HDA-Intel | awk '{print $1}')
+		set_property hal.audio.out.hdmi "pcmC${pcm_card}D8p"
+
+		# unmute them all
+		amixer -c ${pcm_card} sset 'IEC958',0 on
+		amixer -c ${pcm_card} sset 'IEC958',1 on
+		amixer -c ${pcm_card} sset 'IEC958',2 on
+		amixer -c ${pcm_card} sset 'IEC958',3 on
+	fi
 }
 
 function init_hal_bluetooth()
@@ -525,7 +570,7 @@ function init_hal_sensors()
             # is steam deck?
             if [ "$BOARD" == "Jupiter" ]
             then
-                hal_sensors=deck
+                hal_sensors=jupiter
                 has_sensors=true
             fi
     fi

--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -133,4 +133,8 @@
          Software implementation will be used if config_hardware_auto_brightness_available is not set -->
     <bool name="config_automatic_brightness_available">true</bool>
 
+    <!-- If true, the screen can be rotated via the accelerometer in all 4
+         rotations as the default behavior. -->
+    <bool name="config_allowAllRotations">true</bool>
+
 </resources>

--- a/ueventd.x86.rc
+++ b/ueventd.x86.rc
@@ -23,3 +23,10 @@
 
 # USB switch
 /sys/devices/pci0000:00/0000:00:*.0/intel_xhci_usb_sw/usb_role/intel_xhci_usb_sw-role-switch role 0664 system system
+
+# allow binderized sensor hal access input devices
+# note that binderize cannot happen until all sensor hals are ready
+/dev/input/event* 0660 system system
+/dev/hidraw*      0660 system system
+# steamdeck virtual controller built into deck sensor hal
+/dev/uinput       0660 system system


### PR DESCRIPTION
Depends on:
- https://github.com/android-generic/platform_hardware_libsensors/pull/1
- https://github.com/android-generic/platform_hardware_libaudio/pull/1
- https://github.com/android-generic/external_drm_hwcomposer/pull/1
- https://github.com/BlissRoms-x86/platform_system_hardware_interfaces/pull/1
- https://github.com/android-generic/kernel_common/pull/1

only merge when those are done

audio items are targeting gloria branch kernel