### PR TITLE
enable autobrightness

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -133,6 +133,72 @@
          Software implementation will be used if config_hardware_auto_brightness_available is not set -->
     <bool name="config_automatic_brightness_available">true</bool>
 
+    <!-- use celadon_tablet autobrightness values as a one size fit all
+         iio sensor hal allows scaling light sensor values to match these -->
+    <!-- Array of light sensor LUX values to define our levels for auto backlight brightness support.
+         The N entries of this array define N + 1 zones as follows:
+
+         Zone 0:        0 <= LUX < array[0]
+         Zone 1:        array[0] <= LUX < array[1]
+         ...
+         Zone N:        array[N - 1] <= LUX < array[N]
+         Zone N + 1:    array[N] <= LUX < infinity
+
+         Must be overridden in platform specific overlays -->
+    <integer-array name="config_autoBrightnessLevels">
+        <item>50</item>
+        <item>300</item>
+        <item>720</item>
+        <item>2000</item>
+    </integer-array>
+
+    <!-- Array of output values for LCD backlight corresponding to the LUX values
+         in the config_autoBrightnessLevels array.  This array should have size one greater
+         than the size of the config_autoBrightnessLevels array.
+         This must be overridden in platform specific overlays -->
+    <integer-array name="config_autoBrightnessLcdBacklightValues">
+        <item>60</item>
+        <item>100</item>
+        <item>140</item>
+        <item>200</item>
+        <item>250</item>
+    </integer-array>
+
+    <!-- Array of output values for button backlight corresponding to the LUX values
+         in the config_autoBrightnessLevels array.  This array should have size one greater
+         than the size of the config_autoBrightnessLevels array.
+         This must be overridden in platform specific overlays -->
+    <integer-array name="config_autoBrightnessButtonBacklightValues">
+        <item>50</item>
+        <item>0</item>
+        <item>0</item>
+        <item>0</item>
+        <item>0</item>
+    </integer-array>
+
+    <!-- Array of output values for keyboard backlight corresponding to the LUX values
+         in the config_autoBrightnessLevels array.  This array should have size one greater
+         than the size of the config_autoBrightnessLevels array.
+         This must be overridden in platform specific overlays -->
+    <integer-array name="config_autoBrightnessKeyboardBacklightValues">
+        <item>60</item>
+        <item>100</item>
+        <item>140</item>
+        <item>200</item>
+        <item>250</item>
+    </integer-array>
+
+    <!-- default debounce of 4 secs brighten 8 secs darken is a bit slow
+         borrow sunfish's 2 4 secs values instead -->
+    <!-- Stability requirements in milliseconds for accepting a new brightness level.  This is used
+     for debouncing the light sensor.  Different constants are used to debounce the light sensor
+     when adapting to brighter or darker environments.  This parameter controls how quickly
+     brightness changes occur in response to an observed change in light level that exceeds the
+     hysteresis threshold. -->
+    <integer name="config_autoBrightnessBrighteningLightDebounce">2000</integer>
+    <integer name="config_autoBrightnessDarkeningLightDebounce">4000</integer>
+
+
     <!-- If true, the screen can be rotated via the accelerometer in all 4
          rotations as the default behavior. -->
     <bool name="config_allowAllRotations">true</bool>


### PR DESCRIPTION
Screen auto brightness works on my steam deck and thinkpad x380 yoga

can't test the keyboard auto brightness stuffs because the thinkpad does not have software controlled keyboard backlight