### PR TITLE
vulkan.radeon was renamed to vulkan.amd (r11)

### DIFF
--- a/gpu/gpu_mesa.mk
+++ b/gpu/gpu_mesa.mk
@@ -18,7 +18,7 @@ PRODUCT_PACKAGES := \
     modetest \
     vulkan.intel \
     vulkan.intel_hasvk \
-    vulkan.radeon \
+    vulkan.amd \
     vulkan.virtio \
     libEGL_angle \
     libGLESv1_CM_angle \

--- a/init.sh
+++ b/init.sh
@@ -473,7 +473,7 @@ function init_hal_vulkan()
 			fi
 			;;
 		*amdgpu)
-			set_property ro.hardware.vulkan radeon
+			set_property ro.hardware.vulkan amd
 			;;
 		*virtio_gpu)
 			set_property ro.hardware.vulkan virtio


### PR DESCRIPTION
https://github.com/BlissRoms-x86/device_generic_common/pull/18 for r11

not tested but it works in both arcadia and typhoon