### PR TITLE
Load soc_button_array module on Surface

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -656,6 +656,7 @@ function init_hal_surface()
 	case "$UEVENT" in
 		*Surface*Pro*[4-9]*|*Surface*Book*|*Surface*Laptop*[1~4]*|*Surface*Laptop*Studio*)
 			start iptsd_runner
+   			modprobe soc_button_array
 			;;
 	esac
 }


### PR DESCRIPTION
On Microsoft Surface devices, the power and volume buttons are handled by soc_button_array. The commit enables this functionality in Android by loading the soc_button_array kernel module on startup.

(This is my first commit to Bliss btw, lmk if there's a different place I should push this)